### PR TITLE
Add cacheless target

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,3 +34,10 @@ desc 'Lint the Dockerfile'
 task :lint do
   sh %{ docker run --rm -i hadolint/hadolint < Dockerfile }
 end
+
+desc 'Use buildx to make a multi-arch container without using cache'
+task :cacheless do
+  puts "Building #{CONTAINER_NAME}"
+  sh %{ docker buildx build --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME} .}
+  sh %{ docker pull #{CONTAINER_NAME} }
+end


### PR DESCRIPTION
Add a cacheless target so we can force the updates to get downloaded and applied, even if the base debian hasn't been updated yet.