### PR TITLE
Ensure we have the latest setuptools and wheel installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends python3-pip python3-dev && \
 		update-ca-certificates && \
-    pip3 install setuptools wheel --no-cache-dir && \
-    python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade pip setuptools wheel && \
 		rm -fr /tmp/* /var/lib/apt/lists/*
 
 CMD ["bash"]


### PR DESCRIPTION
The `python:slim` images on Dockerhub don't always have the latest `setuptools`, `wheel` or `pip` installed, so make sure we update during image build.

